### PR TITLE
Use window innerWidth/Height instead of documentElement bounding box

### DIFF
--- a/src/inpage.mjs
+++ b/src/inpage.mjs
@@ -73,14 +73,19 @@ export async function inPageRoutine (randomToken, hostOverride) {
     return false
   })
 
-  const documentRect = document.documentElement.getBoundingClientRect()
+  const windowRect = {
+    left: 0,
+    right: window.innerWidth,
+    top: 0,
+    bottom: window.innerHeight
+  }
 
   const visibleElements = contentCheckedElements.filter(node => {
     const nodeRect = node.getBoundingClientRect()
-    if (nodeRect.left >= documentRect.right ||
-        nodeRect.right <= documentRect.left ||
-        nodeRect.top >= documentRect.bottom ||
-        nodeRect.bottom <= documentRect.top) {
+    if (nodeRect.left >= windowRect.right ||
+        nodeRect.right <= windowRect.left ||
+        nodeRect.top >= windowRect.bottom ||
+        nodeRect.bottom <= windowRect.top) {
       return false
     }
     return true


### PR DESCRIPTION
apparently, document.documentElement.getBoundingClientRect can have a height of 0 despite having a sensible clientHeight. However, the clientHeight property has its own quirks. window.innerHeight may be the best option available.

observed on www.france24.com (although not added as a testcase yet since there is a false positive for the keyword check)