### PR TITLE
trim innerText from iframes

### DIFF
--- a/src/inpage.mjs
+++ b/src/inpage.mjs
@@ -113,6 +113,9 @@ export async function inPageRoutine (randomToken, hostOverride) {
       const iframes = node.querySelectorAll('iframe')
       for (const iframe of iframes) {
         const innerText = await hostAPI.extractFrameText(iframe)
+        if (innerText.trim() === '') {
+          continue;
+        }
         const { classifier, classification } = await hostAPI.classifyInnerText(innerText)
         classifiersUsed.add(classifier)
         if (classification) {


### PR DESCRIPTION
there was a false positive on `https://rainberrytv.com` due to an iframe in the header. No `innerText` other than a bunch of newlines and spaces, but somehow the classifier made a decision that it _is_ a cookie notice :shrug: 