### PR TITLE
Return a range of elements rather than 1 single element

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -24,7 +24,7 @@ const args = {
 const CONCURRENCY = Math.max(1, Math.floor(cpus().length / 2))
 console.log(`Running tests with concurrency: ${CONCURRENCY}`)
 
-async function testPage (t, testCasePath, expectedHash, expectedScrollBlocking) {
+async function testPage (t, testCasePath, expectedCookieNotice, expectedScrollBlocking) {
   const url = pathToFileURL(path.join(import.meta.dirname, 'data', testCasePath, 'index.html')).href
   const r = await checkPage({ url, hostOverride: testCasePath, blockNonHttpRequests: false, ...args })
 
@@ -34,17 +34,23 @@ async function testPage (t, testCasePath, expectedHash, expectedScrollBlocking) 
 
   let markupHash
   if (r.identified) {
-    markupHash = createHash('sha256').update(r.markup).digest('base64')
+    markupHash = createHash('sha256').update(r.markupInner).digest('base64')
   }
 
-  const cookieNoticeTestName = expectedHash === undefined
-    ? 'should not detect notice'
-    : 'should detect notice'
-
-  await t.test(cookieNoticeTestName, async (t) => {
-    t.assert.strictEqual(markupHash, expectedHash,
-      `expected hash "${expectedHash}" did not match markup "${markupHash}"`)
-  })
+  if (expectedCookieNotice === undefined) {
+    await t.test('should not detect notice', async (t) => {
+      t.assert.strictEqual(markupHash, expectedCookieNotice,
+        `unexpectedly found cookie notice with markup hash "${markupHash}"`)
+    })
+  } else {
+    const [expectedMarkupHash, expectedRange] = expectedCookieNotice
+    await t.test('should detect notice', async (t) => {
+      t.assert.strictEqual(markupHash, expectedMarkupHash,
+        `expected cookie notice hash "${expectedMarkupHash}" did not match result "${markupHash}"`)
+      t.assert.strictEqual(r.hideableElementRange, expectedRange,
+        `expected cookie notice range "${expectedRange}" did not match result "${r.hideableElementRange}"`)
+    })
+  }
 
   await t.test('scroll blocking detection', async (t) => {
     if (expectedScrollBlocking === undefined) {
@@ -57,71 +63,71 @@ async function testPage (t, testCasePath, expectedHash, expectedScrollBlocking) 
 }
 
 const testCases = [
-  ['2021.rca.ac.uk', 'Xqoe/+M4l2gfBdZ6vazbTr5QaHUl3APEqal4Q3l7wDI=', false],
+  ['2021.rca.ac.uk', ['fOBTu1EHcX9tzkrWM343dsu2kqDUM9w+cMbTc5tm2oc=', 1], false],
   ['abxxx.com', undefined/* TODO */],
   ['bongacams.com', undefined/* TODO */],
   ['brave.com', undefined, false],
-  ['cam4.com', 'O+Y60jG333dyHi6a3W1ZodZ7phKLk1Pr0SzhRHcKSps='/* TODO */],
+  ['cam4.com', ['O+Y60jG333dyHi6a3W1ZodZ7phKLk1Pr0SzhRHcKSps=', 1]/* TODO */],
   ['cleveradvertising.com', undefined, false],
   ['copilot.microsoft.com', undefined, false],
-  ['docs.base.org', 'n7VghBvQo9fKfh5nqf8XLRdgA5KpZc2xjjIla8XHO+k=', false],
-  ['drpc.org', '59blMPXMrimFarphox8PzbXUl7EGzBkqQXlb2DjMJYU=', false],
-  ['euronews.com', '19IiDcdMPth2k2wqKtnGQt5F9wo6Gq6ZzFEHNWCZjnI=', true],
-  ['fortune.com', 'a1+3zJekpAmX/usMwCHTBbpo/osoiNAJpGCKuOBzoLE=', false],
+  ['docs.base.org', ['n7VghBvQo9fKfh5nqf8XLRdgA5KpZc2xjjIla8XHO+k=', 1], false],
+  ['drpc.org', ['59blMPXMrimFarphox8PzbXUl7EGzBkqQXlb2DjMJYU=', 1], false],
+  ['euronews.com', ['19IiDcdMPth2k2wqKtnGQt5F9wo6Gq6ZzFEHNWCZjnI=', 3], true],
+  ['fortune.com', ['a1+3zJekpAmX/usMwCHTBbpo/osoiNAJpGCKuOBzoLE=', 1], false],
   ['freevideo.cz', undefined/* TODO */],
   ['github.com', undefined, false],
   ['goibibo.com', undefined, true],
   ['goodreads.com', undefined, false],
-  ['gostateparks.hawaii.gov', 'JBYwuwip4exVrQIqPUVGz+FWrjnVqwLj8vqq8TXAGs0=', false],
+  ['gostateparks.hawaii.gov', ['JBYwuwip4exVrQIqPUVGz+FWrjnVqwLj8vqq8TXAGs0=', 1], false],
   ['jamieoliver.com', undefined, false],
   ['jetsmart.com', undefined, false],
   ['liu.se', undefined, false],
-  ['login.libero.it', 'EFDuHT+cKspFIMwPpsLit5MBkADL4cFifJSluFLUu6k=', false],
-  ['mamba.ru', '3Cyijp+TBuq8kMOT+yFakpK3GUdgBw3dH5M9x5gLbok=', false],
+  ['login.libero.it', ['EFDuHT+cKspFIMwPpsLit5MBkADL4cFifJSluFLUu6k=', 1], false],
+  ['mamba.ru', ['3Cyijp+TBuq8kMOT+yFakpK3GUdgBw3dH5M9x5gLbok=', 2], false],
   ['massagerepublic.com', undefined, true],
-  ['moovitapp.com', 'yHJeNokduuywPXOjaF6MP9CJ4CBlF+X2H2u28UzLU6Y=', false],
+  ['moovitapp.com', ['yHJeNokduuywPXOjaF6MP9CJ4CBlF+X2H2u28UzLU6Y=', 2], false],
   ['myworldfix.com', undefined, false],
-  ['nordarun.com', '3hfzlWrqxNkDKbXjcST9vWASCuPWUfA1e41DXZMZ82o=', false],
-  ['opensource.fb.com', '+5qjgLXR5vQPllW7bnKVkb97tTv4xG8TdAHJXmhiH2E=', false],
-  ['pleo.io', 'DRv+MeADAubtGiWXFF9agr8Wk9IkZmCZEoUVvK3CqAs=', false],
-  ['primor.eu', 'rNVsKt+hk6dlE1kWFXBFnk1JAbo3RQCca1IRCwOGJPw=', true],
-  ['privatekeys.pw', 'UCeiNrGF2DKp4gRogdcWQlWSrKi93/o6SsJkFpAb20U=', false],
-  ['stripchatgirls.com', 'O87YRCJw7yJGJVXqcPcWzgCuEFcva+67/ZChFxR0ULk='/* TODO */],
-  ['supabase.com', 'fyNq/gQyR53P46zGnFaQmzAcXthZrNTPgpjE5Qp+coE=', false],
-  ['temporal.cloud', 'bMYtB8cqUekB8ICfqzhjKDjkvqLxMMrfVEJsH55J+Pc=', false],
-  ['temporal.io', 'yOY8MZfiQ7cLtdQNOHeOgGlYP6AfZrRRmeZyjCLDIp4=', false],
+  ['nordarun.com', ['3hfzlWrqxNkDKbXjcST9vWASCuPWUfA1e41DXZMZ82o=', 3], false],
+  ['opensource.fb.com', ['+5qjgLXR5vQPllW7bnKVkb97tTv4xG8TdAHJXmhiH2E=', 1], false],
+  ['pleo.io', ['DRv+MeADAubtGiWXFF9agr8Wk9IkZmCZEoUVvK3CqAs=', 1], false],
+  ['primor.eu', ['rNVsKt+hk6dlE1kWFXBFnk1JAbo3RQCca1IRCwOGJPw=', 2], true],
+  ['privatekeys.pw', ['UCeiNrGF2DKp4gRogdcWQlWSrKi93/o6SsJkFpAb20U=', 1], false],
+  ['stripchatgirls.com', ['O87YRCJw7yJGJVXqcPcWzgCuEFcva+67/ZChFxR0ULk=', 1]/* TODO */],
+  ['supabase.com', ['fyNq/gQyR53P46zGnFaQmzAcXthZrNTPgpjE5Qp+coE=', 2], false],
+  ['temporal.cloud', ['bMYtB8cqUekB8ICfqzhjKDjkvqLxMMrfVEJsH55J+Pc=', 1], false],
+  ['temporal.io', ['yOY8MZfiQ7cLtdQNOHeOgGlYP6AfZrRRmeZyjCLDIp4=', 1], false],
   ['videosdemadurasx.com', undefined, false],
   ['vine.co', undefined, false],
-  ['voximplant.com', 'eibP8jYZYDWd1gOydbPONk71HShOp8TeCxdcrY37weI=', false],
-  ['withpersona.com', 'BttgC24/jLdzla0v9kPROTNRLx/guLNXvIJQcGlX0+g=', false],
+  ['voximplant.com', ['eibP8jYZYDWd1gOydbPONk71HShOp8TeCxdcrY37weI=', 1], false],
+  ['withpersona.com', ['BttgC24/jLdzla0v9kPROTNRLx/guLNXvIJQcGlX0+g=', 2], false],
   ['worldoftanks.eu', undefined/* TODO */],
-  ['www.arnotts.com', '+/BFJe+enU6qj0ZxCjZRR54Nvc1UHk4dSJ5othAycE0=', false],
-  ['www.asdatyres.co.uk', 'Qc9jfsaR6bbwRxt3Zgy7TmZpBjKPAOFCTf3D3ddzYoc=', true],
+  ['www.arnotts.com', ['+/BFJe+enU6qj0ZxCjZRR54Nvc1UHk4dSJ5othAycE0=', 1], false],
+  ['www.asdatyres.co.uk', ['Qc9jfsaR6bbwRxt3Zgy7TmZpBjKPAOFCTf3D3ddzYoc=', 1], true],
   ['www.ashemaletube.com', undefined/* TODO */],
-  ['www.epiphone.com', 'xBn4GTL8C3TLWkLdf1iDPXXSWC0Y/QfnTmr6M5bK4sI=', true],
+  ['www.epiphone.com', ['xBn4GTL8C3TLWkLdf1iDPXXSWC0Y/QfnTmr6M5bK4sI=', 1], true],
   ['www.escort.club', undefined, false],
-  ['www.finn.no', 'YLqo3cOckIQCrg0TY5cvEVYKVjguJDBcJTRdZsrrLDM=', true],
-  ['www.france24.com', '429B8Qi/1LdaoPlJvQ9FjGlLvNUnVHIUR/D6eb6DBgE=', true],
-  ['www.g-star.com', 'tElFyJc98b8e1eIcMu7T4AyOR6b0mIaNvOAU6wwcPdU=', false],
-  ['www.heise.de', 'ILZYIEAu9Dh3pcdm7FS9EhQ3RKU8z7cfKVLp3h3NchI=', true],
+  ['www.finn.no', ['YLqo3cOckIQCrg0TY5cvEVYKVjguJDBcJTRdZsrrLDM=', 1], true],
+  ['www.france24.com', ['429B8Qi/1LdaoPlJvQ9FjGlLvNUnVHIUR/D6eb6DBgE=', 3], true],
+  ['www.g-star.com', ['tElFyJc98b8e1eIcMu7T4AyOR6b0mIaNvOAU6wwcPdU=', 2], false],
+  ['www.heise.de', ['ILZYIEAu9Dh3pcdm7FS9EhQ3RKU8z7cfKVLp3h3NchI=', 1], true],
   ['www.intelligems.io', undefined, false],
-  ['www.kafijasdraugs.lv', 'PNqCk+fE2Az2o+hzvNXiqe+HHWh23mmAzrZNd9zeHzo=', true],
-  ['www.kellanova.com', 'aZxeT/PGvgW5wcPMCkeXGJlXw88lC/GfEEJY+0bUXBU=', false],
-  ['www.lyrath.com', 'k2lGP0argaS6Iu+9XWZxDgNim2kFpq6JQGy5o7b6BHc=', false],
-  ['www.meld.io', 'SrMn/AlL+1vb9Ob9MneGIdHzuDVdK0QzOfBpLbBatCQ=', false],
+  ['www.kafijasdraugs.lv', ['PNqCk+fE2Az2o+hzvNXiqe+HHWh23mmAzrZNd9zeHzo=', 2], true],
+  ['www.kellanova.com', ['aZxeT/PGvgW5wcPMCkeXGJlXw88lC/GfEEJY+0bUXBU=', 2], false],
+  ['www.lyrath.com', ['k2lGP0argaS6Iu+9XWZxDgNim2kFpq6JQGy5o7b6BHc=', 1], false],
+  ['www.meld.io', ['SrMn/AlL+1vb9Ob9MneGIdHzuDVdK0QzOfBpLbBatCQ=', 1], false],
   ['www.myway.com', undefined, false],
   ['www.nerdwallet.com', undefined, false],
-  ['www.newsflare.com', 'A1REDzJ4zCkWa3pUNGFFmChRUyObXuXONKwF/QA1s7A=', false],
-  ['www.northcoast.com', 'agltnUgo6/v/bKDMe116cck0BQqmYn17Ma8G1R3ZVm0=', true],
-  ['www.pibank.com', '/R/SbX32j2pKrsl33C+CGURTgOWeC2kNe1PW9VMh098=', true],
+  ['www.newsflare.com', ['A1REDzJ4zCkWa3pUNGFFmChRUyObXuXONKwF/QA1s7A=', 1], false],
+  ['www.northcoast.com', ['agltnUgo6/v/bKDMe116cck0BQqmYn17Ma8G1R3ZVm0=', 1], true],
+  ['www.pibank.com', ['/R/SbX32j2pKrsl33C+CGURTgOWeC2kNe1PW9VMh098=', 1], true],
   ['www.rebelmouse.com', undefined, false],
-  ['www.refinery29.com', '+bdOjXMDngBgmjcnMxUSgSVBw9y0YCBZaGlrmJe9HF8=', true],
-  ['www.rfi.fr', 'pS86reCBOa5gdVYuGEtgrzS7IDgFIQex8Ac5fIwxJgI=', true],
-  ['www.ryanair.com', '1aXesNIeRzje8VpkE6hjGYCeBYPk1nnVpNynB1YCQY8=', false],
-  ['www.unilad.com', '/PXxl4ws/HZVHq2wBHQVO9PtKFNSHHrl1wfCfmoaZ9w=', true],
-  ['www.wardvillage.com', 'RiDcFOm/YVgP1DuCErIfD5/Va9KAXFoem+Pdcn2qZLA=', false],
+  ['www.refinery29.com', ['+bdOjXMDngBgmjcnMxUSgSVBw9y0YCBZaGlrmJe9HF8=', 1], true],
+  ['www.rfi.fr', ['pS86reCBOa5gdVYuGEtgrzS7IDgFIQex8Ac5fIwxJgI=', 3], true],
+  ['www.ryanair.com', ['1aXesNIeRzje8VpkE6hjGYCeBYPk1nnVpNynB1YCQY8=', 1], false],
+  ['www.unilad.com', ['/PXxl4ws/HZVHq2wBHQVO9PtKFNSHHrl1wfCfmoaZ9w=', 1], true],
+  ['www.wardvillage.com', ['RiDcFOm/YVgP1DuCErIfD5/Va9KAXFoem+Pdcn2qZLA=', 1], false],
   ['www.whatnot.com', undefined, false],
-  ['zora.co', 'ZQGVsHwN2dm4XfAmUeYQeV2b0eJxM45CFdQtDyeVjU0=', false]
+  ['zora.co', ['ZQGVsHwN2dm4XfAmUeYQeV2b0eJxM45CFdQtDyeVjU0=', 2], false]
 ]
 
 describe('Cookie consent tests', { concurrency: CONCURRENCY }, () => {


### PR DESCRIPTION
Some cookie notices are structured like the following:
```html
<div>                                      <!-- A -->
  <div id="cookie_notice">                 <!-- B -->
    <div class="backdrop">                 <!-- C -->
      <div class="modal">                  <!-- D -->
        <h1>Your privacy choices</h1>
        ...
      </div>
    </div>
  </div>
</div>
```

In this particular case:
- Element A has no special styling or semantics; it doesn't matter whether or not it is hidden
- Element B has a very convenient ID that could be targeted by a cosmetic filter rule
- It's important to hide element C since it has a backdrop element covering the rest of the page
- Element D is the actual floating notice

The heuristics prior to this PR would identify element C as the cookie notice, when in reality, elements A and B could be hidden with equal success. `.modal:has-text(Your privacy choices)` could be a usable selector, but in this case `#cookie_notice` would be an even better selector to choose since it's more precise (IDs are unique per-page), and procedural filters are more expensive in terms of runtime performance.

In preparation for proposing filter rules, it will be important to calculate this kind of additional context. This PR introduces a "range" of elements that can be hidden. The innermost element **must** be hidden to remove the notice and any associated backdrop elements. Anything up to the outermost element **can** be considered for the purposes of hiding, in order to select the optimal rule.